### PR TITLE
Change README to reflect required "set" option

### DIFF
--- a/README
+++ b/README
@@ -72,21 +72,21 @@ resolutions will be ignored.
 
 Example 1:
     This example works with one or more screens
-    $ screenresolution 800x600x32
+    $ screenresolution set 800x600x32
 Result 1:
     The main display will change to 800x600x32, second screen
     will not be changed
 
 Example 2:
     This example assumes two screens
-    $ screenresolution 800x600x32 800x600x32
+    $ screenresolution set 800x600x32 800x600x32
 Result 2:
     The first and second monitor on the system will be set to 
     800x600x32
 
 Example 3:
     This example assumes two screens
-    $ screen resolution skip 800x600x32
+    $ screen resolution set skip 800x600x32
     This will not touch the first screen but will set the second
     screen to 800x600x32
 


### PR DESCRIPTION
The sample commands in the README did not work previously for me, but they do work if you add the "set" option.
