### PR TITLE
Display Preferred Display Name.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ ARCH_FLAGS=-arch i386 -arch x86_64
 build: screenresolution
 
 screenresolution: main.c cg_utils.o version.h 
-		$(CC) $(CPPFLAGS) $(CFLAGS) $(ARCH_FLAGS) -framework Foundation -framework ApplicationServices $< *.o -o $@
+		$(CC) $(CPPFLAGS) $(CFLAGS) $(ARCH_FLAGS) -framework Foundation -framework ApplicationServices -framework IOKit $< *.o -o $@
 
 %.o: %.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(ARCH_FLAGS) $< -c -o $@

--- a/cg_utils.h
+++ b/cg_utils.h
@@ -22,6 +22,12 @@
 #define __CG_UTILS__H
 
 #include <ApplicationServices/ApplicationServices.h>
+#include <IOKit/graphics/IOGraphicsLib.h>
+
+/*
+#include <CoreVideo/CVBase.h>
+#include <CoreVideo/CVDisplayLink.h>
+*/
 
 // http://stackoverflow.com/questions/3060121/core-foundation-equivalent-for-nslog/3062319#3062319
 #ifndef __OBJC__
@@ -43,5 +49,6 @@ unsigned int configureDisplay(CGDirectDisplayID display,
 unsigned int parseStringConfig(const char *string, struct config *out);
 size_t bitDepth(CGDisplayModeRef mode);
 CFComparisonResult _compareCFDisplayModes (CGDisplayModeRef *mode1Ptr, CGDisplayModeRef *mode2Ptr, void *context);
+char* getPreferredDisplayName(CGDirectDisplayID displayID);
 
 #endif

--- a/main.c
+++ b/main.c
@@ -135,6 +135,8 @@ unsigned int listAvailableModes(CGDirectDisplayID display, int displayNum) {
     int numModes = 0;
     int i;
 
+    char* displayName = getPreferredDisplayName(display);
+
     CFArrayRef allModes = CGDisplayCopyAllDisplayModes(display, NULL);
     if (allModes == NULL) {
         returncode = 0;
@@ -159,7 +161,7 @@ unsigned int listAvailableModes(CGDirectDisplayID display, int displayNum) {
 #ifndef LIST_DEBUG
     if(displayNum != 0)
         printf("\n\n");
-    printf("Available Modes on Display %d\n", displayNum);
+    printf("Available Modes on Display %d (%s)\n", displayNum, displayName);
 #endif
 
     CGDisplayModeRef mode;


### PR DESCRIPTION
When listing display modes, show the display's 'prefferred name'.  This is usually the make/model.
