### PR TITLE
main: include sys/param.c

### DIFF
--- a/main.c
+++ b/main.c
@@ -20,6 +20,7 @@
 
 #include "version.h"
 #include "cg_utils.h"
+#include <sys/param.h>
  
 // Number of modes to list per line.
 #define MODES_PER_LINE 3


### PR DESCRIPTION
The MIN macro is used as of f8f0271beb8c28a6ac95750f931a07337bbcfdbc, but no new header dependency was added for it. Looks like it was indirectly included via something else, but changes to the OS X 10.12 SDK mean the macro is no longer available. This adds an explicit include for the header it comes from.

Fixes #25.
