### PR TITLE
Add getMax to fetch maximum/native resolution

### DIFF
--- a/cg_utils.c
+++ b/cg_utils.c
@@ -136,11 +136,8 @@ unsigned int parseStringConfig(const char *string, struct config *out) {
     return rc;
 }
 
-CFComparisonResult _compareCFDisplayModes (CGDisplayModeRef *mode1Ptr, CGDisplayModeRef *mode2Ptr, void *context)
+CFComparisonResult _compareCFDisplayModes (CGDisplayModeRef mode1, CGDisplayModeRef mode2, void *context)
 {
-    CGDisplayModeRef mode1 = (CGDisplayModeRef)mode1Ptr;
-    CGDisplayModeRef mode2 = (CGDisplayModeRef)mode2Ptr;
-
     size_t width1 = CGDisplayModeGetWidth(mode1);
     size_t width2 = CGDisplayModeGetWidth(mode2);
     

--- a/cg_utils.h
+++ b/cg_utils.h
@@ -42,6 +42,6 @@ unsigned int configureDisplay(CGDirectDisplayID display,
                               int displayNum);
 unsigned int parseStringConfig(const char *string, struct config *out);
 size_t bitDepth(CGDisplayModeRef mode);
-CFComparisonResult _compareCFDisplayModes (CGDisplayModeRef *mode1Ptr, CGDisplayModeRef *mode2Ptr, void *context);
+CFComparisonResult _compareCFDisplayModes (CGDisplayModeRef mode1, CGDisplayModeRef mode2, void *context);
 
 #endif


### PR DESCRIPTION
## Changes
### Fetch max supported mode for each monitor
Newer versions of MacOS use a scaling factor (like 2x, which is the
default for newer MacBooks), leading to the default mode being half the
native resolution of the display. In such cases, it would be desirable
to fetch the maximum resolution supported by the display (native
resolution).

Add a getMax option to fetch this information.

###  Avoid de-reference in _compareCFDisplayModes

Currently, the [`_compareCFDisplayModes`](https://github.com/jhford/screenresolution/blob/f6412127cbb8eb95d00ca7622665cc8a1da50ee2/cg_utils.c#L139-L172) method uses `CGDisplayModeRef*`
as the first and second parameters, in alignment with the
[`CFComparatorFunction`](https://developer.apple.com/documentation/corefoundation/cfcomparatorfunction) type alias declaration expecting an
[`UnsafeRawPointer`](https://developer.apple.com/documentation/swift/unsaferawpointer). But [`CGDisplayModeRef`](https://developer.apple.com/documentation/coregraphics/cgdisplaymoderef?language=objc) is already a pointer to
[`CGDisplayMode`](https://developer.apple.com/documentation/coregraphics/cgdisplaymode) and doesn't need a reference again to work as a
comparator. Doing so also introduces extra referencing and dereferencing
that can be avoided.